### PR TITLE
Basic docs fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,11 @@
-[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fhotwire-django%2Fturbo-django%2Fbadge%3Fref%3Dmain&style=flat)](https://actions-badge.atrox.dev/hotwire-django/turbo-django/goto?ref=main)
-[![Documentation Status](https://readthedocs.org/projects/turbo-django/badge/?version=latest)](https://turbo-django.readthedocs.io/en/latest/?badge=latest)
-[![Issues](https://img.shields.io/github/issues/hotwire-django/turbo-django)](https://img.shields.io/github/issues/hotwire-django/turbo-django)
-[![Twitter](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2FDjangoHotwire)](https://twitter.com/intent/tweet?text=Wow:&url=https%3A%2F%2Fgithub.com%2Fhotwire-django%2Fturbo-django)
+[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fhotwire-django%2Fdjango-turbojs%2Fbadge%3Fref%3Dmain&style=flat)](https://actions-badge.atrox.dev/hotwire-django/django-turbojs/goto?ref=main)
+[![Documentation Status](https://readthedocs.org/projects/django-turbojs/badge/?version=latest)](https://django-turbojs.readthedocs.io/en/latest/?badge=latest)
+[![Issues](https://img.shields.io/github/issues/hotwire-django/django-turbojs)](https://img.shields.io/github/issues/hotwire-django/django-turbojs)
+[![Twitter](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2FDjangoHotwire)](https://twitter.com/intent/tweet?text=Wow:&url=https%3A%2F%2Fgithub.com%2Fhotwire-django%2Fdjango-turbojs)
 
-# Unmaintained // Turbo for Django
+# Hotwired Turbo for Django
 
-> [!WARNING]  
-> This library is unmaintained. Integrating Hotwire and Django is so easy
-> that you are probably better served by writing a little bit of Python in your code
-> than using a full-blown library that adds another level of abstraction.
-> It also seems that the Django community is leaning more towards HTMX than Hotwire
-> so you might want to look over there if you want more "support"
-> (but we still think that Hotwire is very well suited to be used with Django)
-
-Integrate [Hotwire Turbo](https://turbo.hotwired.dev/) with Django with ease.
+Integrate [Hotwire Turbo](https://turbo.hotwired.dev/) with Django with ease. This project is fork of [turbo-django](https://github.com/hotwire-django/turbo-django)
 
 
 ## Requirements
@@ -26,7 +18,7 @@ Integrate [Hotwire Turbo](https://turbo.hotwired.dev/) with Django with ease.
 
 Turbo Django is available on PyPI - to install it, just run:
 
-    pip install turbo-django
+    pip install django-turbojs
 
 Add `turbo` and `channels` to `INSTALLED_APPS`, and copy the following `CHANNEL_LAYERS` setting:
 
@@ -127,10 +119,10 @@ With the `quickstart/` path open in a browser window, watch as the broadcast pus
 
 Now change `.update()` to `.append()` and resend the broadcast a few times.  Notice you do not have to reload the page to get this modified behavior.
 
-Excited to learn more?  Be sure to walk through the [tutorial](https://turbo-django.readthedocs.io/en/latest/index.html) and read more about what Turbo can do for you.
+Excited to learn more?  Be sure to walk through the [tutorial](https://django-turbojs.readthedocs.io/en/latest/index.html) and read more about what Turbo can do for you.
 
 ## Documentation
-Read the [full documentation](https://turbo-django.readthedocs.io/en/latest/index.html) at readthedocs.io.
+Read the [full documentation](https://django-turbojs.readthedocs.io/en/latest/index.html) at readthedocs.io.
 
 
 ## Contribute
@@ -142,6 +134,6 @@ As this new magic is discovered, you can expect to see a few repositories with e
 
 ## License
 
-Turbo-Django is released under the [MIT License](https://opensource.org/licenses/MIT) to keep compatibility with the Hotwire project.
+django-turbojs is released under the [MIT License](https://opensource.org/licenses/MIT) to keep compatibility with the Hotwire project.
 
 If you submit a pull request. Remember to add yourself to `CONTRIBUTORS.md`!

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,5 +2,4 @@ sphinx-autoapi==1.8.1
 sphinx-rtd-theme==0.5.1
 sphinxcontrib-fulltoc==1.2.0
 sphinx_toolbox==2.13.0
--e git+https://github.com/hotwire-django/sphinx-hotwire-theme.git@main#egg=alabaster-hotwire
 jinja2==3.0.0

--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -1,7 +1,0 @@
-div.document {
-    width: 75%;
-}
-div.body {
-    min-width: 450px;
-    max-width: 100%;
-}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -21,9 +21,9 @@ sys.path.insert(0, os.path.abspath("../"))
 
 # -- Project information -----------------------------------------------------
 
-project = 'turbo-django'
-copyright = '2022, Hotwire-Django Team'
-author = 'Hotwire-Django Team'
+project = 'django-turbojs'
+copyright = '2023, Hotwire-Django Team, Sasha Komkov'
+author = 'Hotwire-Django Team, Sasha Komkov'
 
 
 # -- General configuration ---------------------------------------------------
@@ -57,21 +57,5 @@ autodoc_typehints = "description"
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster_hotwire'
+html_theme = 'alabaster'
 
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
-
-html_context = {
-    'topbar': [
-        {"url": "https://turbo-django.readthedocs.io/", "name": "Turbo Django", "active": True},
-        {"url": "https://django-turbo-response.readthedocs.io/", "name": "Django Turbo Response"},
-        {"name": "Stimulus Django"},
-    ]
-}
-
-html_css_files = [
-    'css/custom.css',
-]

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,14 +1,6 @@
-.. warning::
-   This library is unmaintained. Integrating Hotwire and Django is so easy
-   that you are probably better served by writing a little bit of Python in your code
-   than using a full blown library that adds another level of abstraction.
-   It also seems that the Django community is leaning more towards HTMX than Hotwire
-   so you might want to look over there if you want more "support"
-   (but we still think that Hotwire is very well suited to be used with Django)
 
 
-
-Unmaintained // Turbo Django
+Turbo Django
 ============
 
 Turbo Django is a project that integrates the `Hotwire Turbo framework <https://turbo.hotwired.dev/>`_ with `Django <https://www.djangoproject.com/>`_, allowing for rendered page updates to be delivered live, over the wire. By keeping template rendering in Django, dynamic and interactive web pages can be written without any serialization frameworks or JavaScript, dramatically simplifying development.

--- a/doc/source/topics/quickstart.rst
+++ b/doc/source/topics/quickstart.rst
@@ -1,13 +1,6 @@
-.. warning::
-   This library is unmaintained. Integrating Hotwire and Django is so easy
-   that you are probably better served by writing a little bit of Python in your code
-   than using a full blown library that adds another level of abstraction.
-   It also seems that the Django community is leaning more towards HTMX than Hotwire
-   so you might want to look over there if you want more "support"
-   (but we still think that Hotwire is very well suited to be used with Django)
 
 ==========
-Unmaintained//Quickstart
+Quickstart
 ==========
 
 Want to see Turbo in action?  Here's a simple broadcast that can be setup in less than a minute.

--- a/doc/source/tutorial/index.rst
+++ b/doc/source/tutorial/index.rst
@@ -1,13 +1,4 @@
-.. warning::
-   This library is unmaintained. Integrating Hotwire and Django is so easy
-   that you are probably better served by writing a little bit of Python in your code
-   than using a full blown library that adds another level of abstraction.
-   It also seems that the Django community is leaning more towards HTMX than Hotwire
-   so you might want to look over there if you want more "support"
-   (but we still think that Hotwire is very well suited to be used with Django)
-
-
-Unmaintained//Tutorial
+Tutorial
 ========
 
 Turbo-Django allows you to easily integrate the Hotwire Turbo framework into your

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "turbo-django"
+name = "django-turbojs"
 version = "0.4.3"
 description = "Integrate Hotwire Turbo with Django allowing for a Python-driven dynamic web experience."
 authors = [


### PR DESCRIPTION
Just basic docs fix for the beginning: 

- rename to django-turbojs
- delete "unmaintained" warnings